### PR TITLE
aci: update the the name to match final location

### DIFF
--- a/aci/aci-manifest.in
+++ b/aci/aci-manifest.in
@@ -1,7 +1,7 @@
 {
     "acKind": "ImageManifest",
     "acVersion": "0.8.10",
-    "name": "coreos.com/rkt/stage1-skim",
+    "name": "users.developer.core-os.net/skim/stage1-skim",
     "labels": [
         {
             "name": "version",


### PR DESCRIPTION
Previous stage1's are discovered via coreos.com; This one is
experimental and, frankly, it's easier to have the discovery metadata
hosted in the user bucket than on the website.

cc @crawford 